### PR TITLE
Add Open Tech Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | [Mobilizon](https://joinmobilizon.org/en/) | [framagit.org](https://framagit.org/framasoft/mobilizon/) | in development | Elixir | AGPL | 
 | [on_ruby](https://www.onruby.eu/) | [GitHub](https://github.com/phoet/on_ruby) | mature | Ruby | (extended) Beer-ware | 
 | Open Event | GitHub: [Frontend](https://github.com/fossasia/open-event-frontend), [Backend](https://github.com/fossasia/open-event-server) | mature | Python | Apache 2.0 & GPLv3 | 
-| [Open Tech Calendar](https://opentechcalendar.co.uk/) | [GitLab](https://gitlab.com/opentechcalendar)  | mature | PHP, HTML JS | 3-clause BSD | 
+| [Open Tech Calendar](https://opentechcalendar.co.uk/) | [GitLab](https://gitlab.com/opentechcalendar)  | mature | PHP | BSD 3-Clause | 
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | [Mobilizon](https://joinmobilizon.org/en/) | [framagit.org](https://framagit.org/framasoft/mobilizon/) | in development | Elixir | AGPL | 
 | [on_ruby](https://www.onruby.eu/) | [GitHub](https://github.com/phoet/on_ruby) | mature | Ruby | (extended) Beer-ware | 
 | Open Event | GitHub: [Frontend](https://github.com/fossasia/open-event-frontend), [Backend](https://github.com/fossasia/open-event-server) | mature | Python | Apache 2.0 & GPLv3 | 
+| [Open Tech Calendar](https://opentechcalendar.co.uk/) | [GitLab](https://gitlab.com/opentechcalendar)  | mature | PHP, HTML JS | 3-clause BSD | 
 
 ## See also
 


### PR DESCRIPTION
Open Tech Calendar has been used in the Edinburgh and wider Scotland tech scene for quite a few years now. Other instances of it could be hosted, and it could probably be adapted to any goal, not necessarily tech. It has location lookups and notifications, but as far as I know, no billing. It promotes the publishing of open data APIs.