### PR TITLE
Added pretix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 | Open Event                                            | GitHub: [Frontend](https://github.com/fossasia/open-event-frontend), [Backend](https://github.com/fossasia/open-event-server) | mature         | Python           | Apache 2.0 & GPLv3            |
 | [Open Tech Calendar](https://opentechcalendar.co.uk/) | [GitLab](https://gitlab.com/opentechcalendar)                                                                                 | mature         | PHP              | BSD 3-Clause                  |
 | [OpenKi](https://openki.net/)                         | [Gitlab](https://gitlab.com/Openki/Openki/)                                                                                   | mature         | MeteorJS         | AGPLv3                        |
+| [Pretix](https://pretix.eu/)                         | [Gitlab](https://gitlab.com/pretix/pretix/)                                                                                   | mature         | Python         | Apache 2.0                        |
 
 ¹: _mature_ = the project is actively used by groups, _new_ = this is a new project with no usable software, _in development_ = usable software exists, but is not ready for general use
 


### PR DESCRIPTION
If you mention attendize you might also want to mention pretix, another open source ticket shop/checkin system. It's a sister software to Pretalx, https://github.com/pretalx/pretalx, for conference organisation.