### PR TITLE
Add Create Third Places

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 | Calendar.social                                                | [gitea](https://gitea.polonkai.eu/gergely/calendar-social)     | inactive  | Python     | AGPLv3                |
 | Chapter by freeCodeCamp                                        | [GitHub](https://github.com/freeCodeCamp/chapter)              | inactive  | JavaScript | BSD 3-Clause          |
 | [Communecter](https://www.communecter.org/)                    | [GitHub](https://github.com/pixelhumain/communecter)           | inactive  | PHP        | Apache 2.0            |
+| [Create Third Places](https://createthirdplaces.com)           | [GitHub](https://github.com/orgs/createthirdplaces/repositories)           | new  | Java        | GPLv3           |
+
 | Epicyon                                                        | [GitLab](https://gitlab.com/bashrc2/epicyon)                   | new       | Python     | AGPLv3                | :white_check_mark: |
 | [eventoL](http://eventol.github.io/eventoL/)                   | [GitHub](https://github.com/eventoL/eventoL)                   | inactive  | Python     | GPLv3                 |
 | [Events Made Easy](https://www.e-dynamics.be/wordpress/)       | [GitHub](https://github.com/liedekef/events-made-easy/)        | mature    | PHP        | GPLv2.0               |

--- a/README.md
+++ b/README.md
@@ -2,39 +2,38 @@
 
 > :information_source: Pull-requests are welcome!
 
-| Name                                                           | Source                                                         | Maturity¹ | Tech²      | License               | ActivityPub³       |
-| -------------------------------------------------------------- | -------------------------------------------------------------- | --------- | ---------- | --------------------- | ------------------ |
-| [Agorakit](https://agorakit.org/)                              | [GitHub](https://github.com/agorakit/agorakit)                 | mature    | PHP        | GPLv3                 |
-| [attendize](https://www.attendize.com/)                        | [GitHub](https://github.com/Attendize/Attendize)               | inactive  | PHP        | Attribution Assurance |
-| Calendar.social                                                | [gitea](https://gitea.polonkai.eu/gergely/calendar-social)     | inactive  | Python     | AGPLv3                |
-| Chapter by freeCodeCamp                                        | [GitHub](https://github.com/freeCodeCamp/chapter)              | inactive  | JavaScript | BSD 3-Clause          |
-| [Communecter](https://www.communecter.org/)                    | [GitHub](https://github.com/pixelhumain/communecter)           | inactive  | PHP        | Apache 2.0            |
-| [Create Third Places](https://createthirdplaces.com)           | [GitHub](https://github.com/orgs/createthirdplaces/repositories)           | new  | Java        | GPLv3           |
-
-| Epicyon                                                        | [GitLab](https://gitlab.com/bashrc2/epicyon)                   | new       | Python     | AGPLv3                | :white_check_mark: |
-| [eventoL](http://eventol.github.io/eventoL/)                   | [GitHub](https://github.com/eventoL/eventoL)                   | inactive  | Python     | GPLv3                 |
-| [Events Made Easy](https://www.e-dynamics.be/wordpress/)       | [GitHub](https://github.com/liedekef/events-made-easy/)        | mature    | PHP        | GPLv2.0               |
-| [Friendica](https://friendi.ca/)                               | [GitHub](https://github.com/friendica/friendica)               | mature    | PHP        | AGPLv3                |
-| [Gancio](https://gancio.org/)                                  | [Framagit](https://framagit.org/les/gancio)                    | mature    | JavaScript | AGPLv3                | :white_check_mark: |
-| [Gathio](https://gath.io/)                                     | [GitHub](https://github.com/lowercasename/gathio)              | mature    | JavaScript | GPLv3                 |
-| GetTogether                                                    | [GitHub](https://github.com/GetTogetherComm/GetTogether)       | inactive  | Python     | BSD 2-Clause          |
-| Gospeak                                                        | [GitHub](https://github.com/loicknuchel/gospeak)               | inactive  | Scala      | Apache 2.0            |
-| [Hi.Events](https://hi.events/)                                | [GitHub](https://github.com/HiEventsDev/hi.events)             | mature    | PHP        | AGPLv3                |
-| [Hubzilla](https://zotlabs.org/page/hubzilla/hubzilla-project) | [Framagit](https://framagit.org/hubzilla/core)                 | mature    | PHP        | MIT                   |
-| [Human Connection](https://human-connection.social/)           | [GitHub](https://github.com/Human-Connection/Human-Connection) | inactive  | JavaScript | MIT                   |
-| [joind.in](https://joind.in/)                                  | [GitHub](https://github.com/joindin/joindin-web2)              | inactive  | PHP        | BSD 3-Clause          |
-| [Lauti](https://lauti.org/)                                    | [Codeberg](https://codeberg.org/Klasse-Methode/lauti)          | mature    | Golang     | AGPLv3                |
-| [Meetdown](https://meetdown.org/)                              | [GitHub](https://github.com/structr/meetdown)                  | inactive  | Structr    | Apache 2.0            |
-| Meetup Alternative                                             | [GitHub](https://github.com/Thinkmill/meetup-alternative)      | inactive  | JavaScript | unlicensed            |
-| [Mobilizon](https://mobilizon.org/)                            | [Framagit](https://framagit.org/kaihuri/mobilizon)             | mature    | Elixir     | AGPLv3                | :white_check_mark: |
-| [on_ruby](https://www.onruby.eu/)                              | [GitHub](https://github.com/phoet/on_ruby)                     | mature    | Ruby       | (extended) Beer-ware  |
-| Open Event                                                     | [GitHub](https://github.com/fossasia/open-event-server)        | mature    | Python     | Apache 2.0 & GPLv3    |
-| [Open Tech Calendar](https://opentechcalendar.co.uk/)          | [GitLab](https://gitlab.com/opentechcalendar/opentechcalendar) | inactive  | PHP        | BSD 3-Clause          |
-| [Openki](https://openki.net/)                                  | [Gitlab](https://gitlab.com/Openki/Openki/)                    | mature    | JavaScript | AGPLv3                |
-| [OSEM](https://osem.io/)                                       | [GitHub](https://github.com/openSUSE/osem)                     | mature    | Ruby       | MIT                   |
-| [Pretix](https://pretix.eu/)                                   | [GitHub](https://github.com/pretix/pretix)                     | mature    | Python     | Apache 2.0            |
-| [Upcoming](https://upcoming.org/)                              | [GitHub](https://github.com/upcoming/upcoming-www)             | inactive  | JavaScript | Apache 2.0            |
-| [wp-event-manager](https://wp-eventmanager.com/)               | [GitHub](https://github.com/wpeventmanager/wp-event-manager)   | mature    | PHP        | GPLv3                 |
+| Name                                                           | Source                                                          | Maturity¹ | Tech²      | License               | ActivityPub³       |
+| -------------------------------------------------------------- | --------------------------------------------------------------- | --------- | ---------- | --------------------- | ------------------ |
+| [Agorakit](https://agorakit.org/)                              | [GitHub](https://github.com/agorakit/agorakit)                  | mature    | PHP        | GPLv3                 |
+| [attendize](https://www.attendize.com/)                        | [GitHub](https://github.com/Attendize/Attendize)                | inactive  | PHP        | Attribution Assurance |
+| Calendar.social                                                | [gitea](https://gitea.polonkai.eu/gergely/calendar-social)      | inactive  | Python     | AGPLv3                |
+| Chapter by freeCodeCamp                                        | [GitHub](https://github.com/freeCodeCamp/chapter)               | inactive  | JavaScript | BSD 3-Clause          |
+| [Communecter](https://www.communecter.org/)                    | [GitHub](https://github.com/pixelhumain/communecter)            | inactive  | PHP        | Apache 2.0            |
+| [Create Third Places](https://createthirdplaces.com)           | [GitHub](https://github.com/orgs/createthirdplaces/repositories)| new  | Java        | GPLv3           |
+| Epicyon                                                        | [GitLab](https://gitlab.com/bashrc2/epicyon)                    | new       | Python     | AGPLv3                | :white_check_mark: |
+| [eventoL](http://eventol.github.io/eventoL/)                   | [GitHub](https://github.com/eventoL/eventoL)                    | inactive  | Python     | GPLv3                 |
+| [Events Made Easy](https://www.e-dynamics.be/wordpress/)       | [GitHub](https://github.com/liedekef/events-made-easy/)         | mature    | PHP        | GPLv2.0               |
+| [Friendica](https://friendi.ca/)                               | [GitHub](https://github.com/friendica/friendica)                | mature    | PHP        | AGPLv3                |
+| [Gancio](https://gancio.org/)                                  | [Framagit](https://framagit.org/les/gancio)                     | mature    | JavaScript | AGPLv3                | :white_check_mark: |
+| [Gathio](https://gath.io/)                                     | [GitHub](https://github.com/lowercasename/gathio)               | mature    | JavaScript | GPLv3                 |
+| GetTogether                                                    | [GitHub](https://github.com/GetTogetherComm/GetTogether)        | inactive  | Python     | BSD 2-Clause          |
+| Gospeak                                                        | [GitHub](https://github.com/loicknuchel/gospeak)                | inactive  | Scala      | Apache 2.0            |
+| [Hi.Events](https://hi.events/)                                | [GitHub](https://github.com/HiEventsDev/hi.events)              | mature    | PHP        | AGPLv3                |
+| [Hubzilla](https://zotlabs.org/page/hubzilla/hubzilla-project) | [Framagit](https://framagit.org/hubzilla/core)                  | mature    | PHP        | MIT                   |
+| [Human Connection](https://human-connection.social/)           | [GitHub](https://github.com/Human-Connection/Human-Connection)  | inactive  | JavaScript | MIT                   |
+| [joind.in](https://joind.in/)                                  | [GitHub](https://github.com/joindin/joindin-web2)               | inactive  | PHP        | BSD 3-Clause          |
+| [Lauti](https://lauti.org/)                                    | [Codeberg](https://codeberg.org/Klasse-Methode/lauti)           | mature    | Golang     | AGPLv3                |
+| [Meetdown](https://meetdown.org/)                              | [GitHub](https://github.com/structr/meetdown)                   | inactive  | Structr    | Apache 2.0            |
+| Meetup Alternative                                             | [GitHub](https://github.com/Thinkmill/meetup-alternative)       | inactive  | JavaScript | unlicensed            |
+| [Mobilizon](https://mobilizon.org/)                            | [Framagit](https://framagit.org/kaihuri/mobilizon)              | mature    | Elixir     | AGPLv3                | :white_check_mark: |
+| [on_ruby](https://www.onruby.eu/)                              | [GitHub](https://github.com/phoet/on_ruby)                      | mature    | Ruby       | (extended) Beer-ware  |
+| Open Event                                                     | [GitHub](https://github.com/fossasia/open-event-server)         | mature    | Python     | Apache 2.0 & GPLv3    |
+| [Open Tech Calendar](https://opentechcalendar.co.uk/)          | [GitLab](https://gitlab.com/opentechcalendar/opentechcalendar)  | inactive  | PHP        | BSD 3-Clause          |
+| [Openki](https://openki.net/)                                  | [Gitlab](https://gitlab.com/Openki/Openki/)                     | mature    | JavaScript | AGPLv3                |
+| [OSEM](https://osem.io/)                                       | [GitHub](https://github.com/openSUSE/osem)                      | mature    | Ruby       | MIT                   |
+| [Pretix](https://pretix.eu/)                                   | [GitHub](https://github.com/pretix/pretix)                      | mature    | Python     | Apache 2.0            |
+| [Upcoming](https://upcoming.org/)                              | [GitHub](https://github.com/upcoming/upcoming-www)              | inactive  | JavaScript | Apache 2.0            |
+| [wp-event-manager](https://wp-eventmanager.com/)               | [GitHub](https://github.com/wpeventmanager/wp-event-manager)    | mature    | PHP        | GPLv3                 |
 
 ## Table Keys
 


### PR DESCRIPTION
I'm working on a decentralized open source platform called Create Third Places, which will help people find and host in perso  events. These are the guidelines will be followed for any changes.

-  Support in person interaction
 - All content is human generated
 - No personalized recommendations
 - No commercial monetization
 - Promote decentralization

The decentralized architecture will involve having 2 types of websites. The first will be local independent websites, and the second will be aggregator websites that combine data from other websites. Create Third Place also includes a [new JavaScript framework](https://createthirdplaces.com/static/tech/placesjs.html) for interactive websites promoting in person interaction, and I'm working on guides to help people host events.

 As a starting point, I am working on a website for in person board games in the Washington, D. C. area at [dmvboardgames.com](dmvboardgames.com). It currently has support for creating groups, events, and event signups. Source code is [here](https://github.com/orgs/gatherspiel/repositories)

More technical details are [here](https://createthirdplaces.com/static/events/decentralizedEventHosting.html)

<img width="1034" height="1587" alt="Screenshot from 2025-12-25 23-00-01" src="https://github.com/user-attachments/assets/deb8415a-f1b1-46b4-aa13-cbf75dbecb7a" />
